### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,7 @@ jobs:
         dst: |
           docker.io/fonoster/healthcheck:${{ steps.get_version.outputs.VERSION }}             
     - name: Publish to Docker Hub the Fonoster installer
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       env:
         FONOSTER_VERSION: ${{ steps.get_version.outputs.VERSION }}
         BRANCH: main
@@ -113,7 +113,7 @@ jobs:
         tags: "latest, ${{ steps.get_version.outputs.VERSION }}"
         buildargs: FONOSTER_VERSION,BRANCH          
     - name: Publish to Docker Hub the Projects API
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: fonoster/projects
         username: ${{ secrets.DOCKER_HUB_USERNAME }}
@@ -121,7 +121,7 @@ jobs:
         workdir: mods/projects
         tags: "latest, ${{ steps.get_version.outputs.VERSION }}"
     - name: Publish to Docker Hub the Monitor API
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: fonoster/monitor
         username: ${{ secrets.DOCKER_HUB_USERNAME }}
@@ -129,7 +129,7 @@ jobs:
         workdir: mods/monitor
         tags: "latest, ${{ steps.get_version.outputs.VERSION }}"        
     - name: Publish to Docker Hub the Users API
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: fonoster/users
         username: ${{ secrets.DOCKER_HUB_USERNAME }}
@@ -137,7 +137,7 @@ jobs:
         workdir: mods/users
         tags: "latest, ${{ steps.get_version.outputs.VERSION }}"        
     - name: Publish to Docker Hub the Secrets API 
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: fonoster/secrets
         username: ${{ secrets.DOCKER_HUB_USERNAME }}
@@ -145,7 +145,7 @@ jobs:
         workdir: mods/secrets
         tags: "latest, ${{ steps.get_version.outputs.VERSION }}"        
     - name: Publish to Docker Hub the Funcs API 
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: fonoster/funcs
         username: ${{ secrets.DOCKER_HUB_USERNAME }}
@@ -153,7 +153,7 @@ jobs:
         workdir: mods/funcs
         tags: "latest, ${{ steps.get_version.outputs.VERSION }}"
     - name: Publish to Docker Hub the Agents API 
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: fonoster/agents
         username: ${{ secrets.DOCKER_HUB_USERNAME }}
@@ -161,7 +161,7 @@ jobs:
         workdir: mods/agents
         tags: "latest, ${{ steps.get_version.outputs.VERSION }}"
     - name: Publish to Docker Hub the Domains API 
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: fonoster/domains
         username: ${{ secrets.DOCKER_HUB_USERNAME }}
@@ -169,7 +169,7 @@ jobs:
         workdir: mods/domains
         tags: "latest, ${{ steps.get_version.outputs.VERSION }}"
     - name: Publish to Docker Hub the Numbers API
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: fonoster/numbers
         username: ${{ secrets.DOCKER_HUB_USERNAME }}
@@ -177,7 +177,7 @@ jobs:
         workdir: mods/numbers
         tags: "latest, ${{ steps.get_version.outputs.VERSION }}"
     - name: Publish to Docker Hub the Providers API
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: fonoster/providers
         username: ${{ secrets.DOCKER_HUB_USERNAME }}
@@ -185,7 +185,7 @@ jobs:
         workdir: mods/providers
         tags: "latest, ${{ steps.get_version.outputs.VERSION }}"
     - name: Publish to Docker Hub the Storage API
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: fonoster/storage
         username: ${{ secrets.DOCKER_HUB_USERNAME }}
@@ -193,7 +193,7 @@ jobs:
         workdir: mods/storage
         tags: "latest, ${{ steps.get_version.outputs.VERSION }}"
     - name: Publish to Docker Hub the CallManager API
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: fonoster/callmanager
         username: ${{ secrets.DOCKER_HUB_USERNAME }}
@@ -201,7 +201,7 @@ jobs:
         workdir: mods/callmanager
         tags: "latest, ${{ steps.get_version.outputs.VERSION }}"
     - name: Publish to Docker Hub the Auth API
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: fonoster/auth
         username: ${{ secrets.DOCKER_HUB_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore